### PR TITLE
Add Release Flow

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,0 +1,49 @@
+name: Deploy Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        name: release
+        description: Release tag (e.g. v0.0.1)
+
+      network:
+        name: network
+        options:
+          - mainnet
+          - sepolia
+          - base
+          - base_sepolia
+
+env:
+  FOUNDRY_PROFILE: ci
+
+permissions:
+  contents: write
+
+jobs:
+  check:
+    strategy:
+      fail-fast: true
+
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Deploy Release
+        run: |
+          export RPC_URL=$(echo $deployer_config | jq -r ".$network.rpc_url")
+          export DEPLOYER_PK=$(echo $deployer_config | jq -r ".$network.deployer_pk")
+          script/deploy-release.sh $tag
+        env:
+          deployer_config: ${{ secrets.deployer_config }}
+          network: sepolia
+          tag: v0.0.1

--- a/.github/workflows/deploy-wallet-connect.yml
+++ b/.github/workflows/deploy-wallet-connect.yml
@@ -1,4 +1,4 @@
-name: Deploy Sleuth [Mainnet]
+name: Deploy Sleuth [Mainnet - WalletConnect]
 
 on:
   workflow_dispatch:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -34,10 +34,12 @@ jobs:
 
       - name: Prepare Release
         run: |
+          export RPC_URL=$(echo $deployer_config | jq ".$network.rpc_url")
+          export CODE_JAR=$(echo $deployer_config | jq ".$network.code_jar")
           script/prepare-release.sh
         env:
-          CODE_JAR: ${{ vars.CODE_JAR }}
-          RPC_URL: ${{ vars.SEPOLIA_RPC_URL }}
+          deployer_config: ${{ secrets.deployer_config }}
+          network: sepolia
 
       - uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Prepare Release
+
+on:
+  push:
+    tags:
+    - '*'
+
+env:
+  FOUNDRY_PROFILE: ci
+
+permissions:
+  contents: write
+
+jobs:
+  check:
+    strategy:
+      fail-fast: true
+
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run Forge build
+        run: |
+          forge build
+
+      - name: Prepare Release
+        run: |
+          script/prepare-release.sh
+        env:
+          CODE_JAR: ${{ vars.CODE_JAR }}
+          RPC_URL: ${{ vars.SEPOLIA_RPC_URL }}
+
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "release/Sleuth.json,release/Sleuth.sol,release/contracts.json,release/sleuth@*"
+          bodyFile: "release/RELEASE.md"
+          allowUpdates: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: test
 
-on: workflow_dispatch
+on:
+  push:
 
 env:
   FOUNDRY_PROFILE: ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Compiler files
 cache/
 out/
+release/
+.release-tmp/
 
 # Ignores development broadcast logs
 !/broadcast

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,9 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-fs_permissions = [{ access = "read", path = "./out"}]
+fs_permissions = [
+  { access = "read", path = "./out"},
+  { access = "read", path = "./release"}
+]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@ out = 'out'
 libs = ['lib']
 fs_permissions = [
   { access = "read", path = "./out"},
-  { access = "read", path = "./release"}
+  { access = "read", path = "./.release-tmp"}
 ]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/script/Sleuth.s.sol
+++ b/script/Sleuth.s.sol
@@ -30,7 +30,7 @@ contract Deploy is Script {
     function setUp() public {}
 
     function run() public returns (address) {
-        bytes memory sleuthCreationCode = vm.getCode("release/Sleuth.json");
+        bytes memory sleuthCreationCode = vm.getCode("./.release-tmp/Sleuth.json");
         CodeJar codeJar = CodeJar(vm.envAddress("CODE_JAR"));
         address expectedSleuthAddress = vm.envAddress("SLEUTH_ADDRESS");
         address sleuthAddress = codeJar.saveCode(sleuthCreationCode);

--- a/script/Sleuth.s.sol
+++ b/script/Sleuth.s.sol
@@ -1,12 +1,48 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.23;
 
 import "forge-std/Script.sol";
+import "../src/Sleuth.sol";
 
-contract SleuthScript is Script {
+interface CodeJar {
+    function saveCode(bytes memory code) external returns (address);
+}
+
+contract Prepare is Script {
     function setUp() public {}
 
-    function run() public {
-        vm.broadcast();
+    function run() public returns (address) {
+        CodeJar codeJar = CodeJar(vm.envAddress("CODE_JAR"));
+        console.log("Code Jar Address:", address(codeJar));
+        console.log("Chain ID:", block.chainid);
+        console.logBytes(address(codeJar).code);
+
+        address sleuthAddress = codeJar.saveCode(type(Sleuth).creationCode);
+
+        console.log("Sleuth Address:", sleuthAddress);
+
+        return sleuthAddress;
+    }
+}
+
+contract Deploy is Script {
+    error MismatchedSleuthAddress(address expected, address actual);
+    function setUp() public {}
+
+    function run() public returns (address) {
+        bytes memory sleuthCreationCode = vm.getCode("release/Sleuth.json");
+        CodeJar codeJar = CodeJar(vm.envAddress("CODE_JAR"));
+        address expectedSleuthAddress = vm.envAddress("SLEUTH_ADDRESS");
+        address sleuthAddress = codeJar.saveCode(sleuthCreationCode);
+        if (sleuthAddress != expectedSleuthAddress) {
+            revert MismatchedSleuthAddress(expectedSleuthAddress, sleuthAddress);
+        }
+        vm.startBroadcast();
+        sleuthAddress = codeJar.saveCode(sleuthCreationCode);
+        vm.stopBroadcast();
+
+        console.log("Sleuth Address:", sleuthAddress);
+
+        return sleuthAddress;
     }
 }

--- a/script/deploy-release.sh
+++ b/script/deploy-release.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eo pipefail
+
+tag="$1"
+
+if [ -z "$tag" ]; then
+  echo "usage script/deploy-release.sh <tag>"
+  exit 1
+fi
+
+rm -rf .release-tmp
+mkdir .release-tmp
+
+curl -L "https://github.com/compound-finance/sleuth/releases/download/$tag/Sleuth.json" -o ./.release-tmp/Sleuth.json
+curl -L "https://github.com/compound-finance/sleuth/releases/download/$tag/contracts.json" -o ./.release-tmp/contracts.json
+
+if [ -z "$RPC_URL" ]; then
+  echo "Missing RPC_URL env var"
+  exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "jq could not be found"
+    exit 1
+fi
+
+export SLEUTH_ADDRESS="$(cat ./.release-tmp/contracts.json | jq -r '.sleuth')"
+export CODE_JAR="$(cat ./.release-tmp/contracts.json | jq -r '.codeJar')"
+
+forge script \
+  --rpc-url="$RPC_URL" \
+  script/Sleuth.s.sol:Deploy \
+  $@
+
+# TODO: Verify

--- a/script/deploy-release.sh
+++ b/script/deploy-release.sh
@@ -9,6 +9,24 @@ if [ -z "$tag" ]; then
   exit 1
 fi
 
+opts=""
+
+if [ -n "$DEPLOYER_PK" ]; then
+  opts="$opts --private-key $DEPLOYER_PK --broadcast"
+fi
+
+if [ -n "$ETHERSCAN_API_KEY" ]; then
+  opts="$opts --verify --etherscan-api-key \"$ETHERSCAN_API_KEY\""
+fi
+
+cleanup() {
+    rv=$?
+    rm -rf .release-tmp
+    exit $rv
+}
+
+trap "cleanup" EXIT
+
 rm -rf .release-tmp
 mkdir .release-tmp
 
@@ -30,7 +48,6 @@ export CODE_JAR="$(cat ./.release-tmp/contracts.json | jq -r '.codeJar')"
 
 forge script \
   --rpc-url="$RPC_URL" \
+  $opts \
   script/Sleuth.s.sol:Deploy \
   $@
-
-# TODO: Verify

--- a/script/prepare-release.sh
+++ b/script/prepare-release.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -eo pipefail
+
+if [ -z "$CODE_JAR" ]; then
+  echo "Missing CODE_JAR env var"
+  exit 1
+fi
+
+if [ -z "$RPC_URL" ]; then
+  echo "Missing RPC_URL env var"
+  exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "jq could not be found"
+    exit 1
+fi
+
+forge build
+mkdir -p release/
+cp out/Sleuth.sol/Sleuth.json release/
+cp src/Sleuth.sol release/
+title="$(git log -1 --pretty="%s")"
+body="$(git log -1 --pretty="%b")"
+
+if [ -z "$title" ]; then
+  echo "must include git commit title"
+  exit 1
+fi
+
+if [ -z "$body" ]; then
+  echo "must include git commit body"
+  exit 1
+fi
+
+sleuth_address="$(forge script --rpc-url="$RPC_URL" --json --silent script/Sleuth.s.sol:Prepare | tee | jq -r '.returns."0".value')"
+
+echo "title=$title"
+echo "body=$body"
+echo "sleuth_address=$sleuth_address"
+
+echo "$sleuth_address" > "release/sleuth@$sleuth_address"
+
+cat > release/RELEASE.md <<EOF
+## $title
+
+Sleuth Address: $sleuth_address
+
+$body
+EOF
+
+cat > release/contracts.json <<EOF
+{
+  "sleuth": "$sleuth_address",
+  "codeJar": "$CODE_JAR"
+}
+EOF


### PR DESCRIPTION
This patch adds a release flow that let's us build releases and then deploy them separately. Since deploys are deterministic, this "release first, deploy later" flow should be quite appealing. e.g. it means you can always redeploy older releases to new chains, etc.