### PR TITLE
allow `contractAddress` as an opt when initializing sleuth

### DIFF
--- a/cli/sleuth.ts
+++ b/cli/sleuth.ts
@@ -7,7 +7,8 @@ import { parse } from '../parser/pkg/parser';
 
 interface Opts {
   network?: string,
-  version?: number
+  version?: number,
+  contractAddress?: string
 };
 
 const defaultOpts = {
@@ -90,7 +91,7 @@ export class Sleuth {
     this.provider = provider;
     this.network = opts.network ?? defaultOpts.network;
     this.version = opts.version ?? defaultOpts.version;
-    this.sleuthAddr = getContractAddress({ from: sleuthDeployer, nonce: this.version - 1 });
+    this.sleuthAddr = opts.contractAddress ?? getContractAddress({ from: sleuthDeployer, nonce: this.version - 1 });
     this.sources = [];
     this.coder = new AbiCoder();
   }


### PR DESCRIPTION
Allow passing in `contractAddress` manually as an option when initializing Sleuth.

The current implementation assumes a deterministic address for all chains - because it assumes the same deployer address is used with the same nonce (0).

While this was true for all chains so far, our deployment on Mantle used a nonce of 4 (we used a few transactions to get the native token), which led to the contract being deployed on a different address than the usual `0xC6a613FdaC3465D250DF7FF3CC21Bec86Eb8A372`.

On the client side we'd then make an exception for Mantle and pass in that new address as a flag.